### PR TITLE
Constrain monad-control, disambiguate type

### DIFF
--- a/Control/Concurrent/Async/Pool/Internal.hs
+++ b/Control/Concurrent/Async/Pool/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Control.Concurrent.Async.Pool.Internal where
 
@@ -251,7 +252,7 @@ scatterFoldMapM p fs f = do
     hs <- liftBase $ atomically
                   $ sequenceA
                   $ foldMap ((:[]) <$> asyncUsing p rawForkIO) fs
-    control $ \run -> loop run (run $ return mempty) (toList hs)
+    control $ \(run :: m b -> IO (StM m b)) -> loop run (run $ return mempty) (toList hs)
   where
     loop _ z [] = z
     loop run z hs = do

--- a/async-pool.cabal
+++ b/async-pool.cabal
@@ -27,7 +27,7 @@ Library
       , containers
       , transformers
       , transformers-base
-      , monad-control
+      , monad-control >= 1.0 && < 1.1
     exposed-modules:
         Control.Concurrent.Async.Pool
     other-modules:


### PR DESCRIPTION
I thought I'd do the initial leg work on this to make things easier. This likely resolves #5. All the tests pass on my end for 7.6.3 and 7.8.4, but it would probably be a good idea to look it over since I'm no expert on `monad-control`.