### PR TITLE
Bump base for GHC 8.2.1 support

### DIFF
--- a/async-pool.cabal
+++ b/async-pool.cabal
@@ -20,7 +20,7 @@ Library
     default-language: Haskell98
     ghc-options:      -Wall
     build-depends:
-        base >= 3 && < 4.10
+        base >= 3 && < 4.11
       , fgl
       , async
       , stm


### PR DESCRIPTION
Hi John,

Thanks for this package. I've bumped `base` to so the package can be used with GHC 8.2.1. The tests are still passing.

Thanks!
Brian