### PR TITLE
Raise upper bound on base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /TaskPool
 /Setup
 /dist/
+.stack-work/*

--- a/async-pool.cabal
+++ b/async-pool.cabal
@@ -20,7 +20,7 @@ Library
     default-language: Haskell98
     ghc-options:      -Wall
     build-depends:
-        base >= 3 && < 4.12
+        base >= 3 && < 4.13
       , fgl
       , async
       , stm

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-13.0
+packages:
+- .
+extra-deps:
+- fgl-5.7.0.1


### PR DESCRIPTION
Compiles with GHC 8.6 now.

This also adds a `stack.yaml` file to build the project with stack