### PR TITLE
Add lower-bounds

### DIFF
--- a/async-pool.cabal
+++ b/async-pool.cabal
@@ -20,14 +20,14 @@ Library
     default-language: Haskell98
     ghc-options:      -Wall
     build-depends:
-        base >= 3 && < 4.13
-      , fgl
-      , async
-      , stm
-      , containers
+        base               >= 4.6     && < 4.13
+      , fgl                >= 5.4.2.2
+      , async              >= 2.0.0.0
+      , stm                >= 2.3
+      , containers         >= 0.5.0.0
       , transformers
       , transformers-base
-      , monad-control >= 1.0 && < 1.1
+      , monad-control      >= 1.0     && < 1.1
     exposed-modules:
         Control.Concurrent.Async.Pool
     other-modules:


### PR DESCRIPTION
- base >=4.6: Ambiguous `catch`. `catch` was removed from Prelude in base-4.6
- async >=2.0.0.0: `Control.Concurrent.Async` module
- stm >=2.3: needs `modifyTVar'
- fgl >=5.4.2.2: needs `Data.Graph.Inductive.PatriciaTree` module (fgl violated PVP by introducing new module in patch release).
- containers >=0.5.0.0 to correspond with base >=4.6/GHC-7.6 technically older `containers` could work but I didn't test properly. containers-0.2 **didn't** work.
- I didn't add bounds to `transformers` neither `transformers-base`, as all reachable versions seems to work.

---

I made revisions adding these bounds to the released async-pool versions:
- also relaxed `base` upper bound in 0.9.0.2 as requested in https://github.com/haskell-infra/hackage-trustees/issues/229 ; the revision: https://hackage.haskell.org/package/async-pool-0.9.0.2/revisions/
- I also added upper bounds to older releases (0.9.0.2 is upper-boundless), e.g. https://hackage.haskell.org/package/async-pool-0.9.0.1/revisions/ so they won't bitrot in the future.